### PR TITLE
Swap out q-io for needle on server-side jQuery.ajax shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+build/
+node_modules/
+*.swp
+*.swo
+.lvimrc
 *~

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
     concat: {
       dist: {
         src: ['src/base.js','build/endpoints.js', 'src/core.js',
-              'src/add.js', 'src/note.js'],
+              'src/add.js', 'src/note.js', 'src/recipes.js'],
         dest: 'dist/appnet.js'
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "version": "0.4.0",
   "contributors": [
     "Jonathon Duerig <duerig@jonathonduerig.com> (http://alpha.app.net/duerig)",
-    "Michael Vezie (http://alpha.app.net/mlv)"],
+    "Michael Vezie (http://alpha.app.net/mlv)"
+  ],
   "description": "A library for communicating with the app.net web services API.",
-  "keywords": ["social", "app.net", "appnet", "adn"],
+  "keywords": [
+    "social",
+    "app.net",
+    "appnet",
+    "adn"
+  ],
   "homepage": "http://github.com/duerig/appnet.js",
   "bugs": {
     "url": "http://github.com/duerig/appnetjs/issues",
@@ -18,10 +24,9 @@
   },
   "dependencies": {
     "q": "~0.9.6",
-    "q-io": "~1.9.1",
     "querystring": "~0.2.0",
-    "streamifier": "~0.0.2",
-    "xtend": "~2.0.6"
+    "xtend": "~2.0.6",
+    "needle": "~0.6.3"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -31,6 +36,8 @@
     "grunt-contrib-concat": "~0.3.0",
     "assemble": "~0.3.77"
   },
-  "files": ["dist/appnet.js"],
+  "files": [
+    "dist/appnet.js"
+  ],
   "main": "dist/appnet.js"
 }

--- a/src/base.js
+++ b/src/base.js
@@ -78,7 +78,7 @@ if (typeof exports !== 'undefined')
 
     needle.request(options.type, options.url, options.data, options, function (error, response, body)
     {
-      if (error !== undefined || response.status !== 200)
+      if (error || response.statusCode !== 200)
       {
         deferred.reject(response);
       }
@@ -103,7 +103,8 @@ if (typeof exports !== 'undefined')
     appToken: null,
     endpoints: null,
     core: {},
-    note: {}
+    note: {},
+    recipes: {}
   };
 
   appnet.authorize = function (user, app)

--- a/src/recipes.js
+++ b/src/recipes.js
@@ -1,0 +1,62 @@
+/*
+ * recipes.js
+ *
+ * Shortcuts for manipulating App.net objects.
+ *
+ */
+
+/*global jQuery: true */
+(function ($) {
+  'use strict';
+
+  var BroadcastMessageBuilder = function() {
+  };
+
+  BroadcastMessageBuilder.prototype.send = function () {
+    var self = this;
+
+    var parseLinks = this.parseLinks || this.parseMarkdownLinks;
+
+    var message = {
+      annotations: [],
+      entities: {
+        parse_links: !!parseLinks,
+        parse_markdown_links: !!this.parseMarkdownLinks
+      }
+    };
+
+    // photo
+    //
+    // attachment
+    //
+
+    if (this.text) {
+      message.text = this.text;
+    } else {
+      message.machine_only = true;
+    }
+
+    if (this.headline) {
+      message.annotations.push({
+        type: 'net.app.core.broadcast.message.metadata',
+        value: {
+          subject: this.headline
+        }
+      });
+    }
+
+    if (this.readMoreLink) {
+      message.annotations.push({
+        type: 'net.app.core.crosspost',
+        value: {
+          canonical_url: this.readMoreLink
+        }
+      });
+    }
+
+    return $.appnet.message.create(this.channelID, message);
+  };
+
+  $.appnet.recipes.BroadcastMessageBuilder = BroadcastMessageBuilder;
+
+}(jQuery));


### PR DESCRIPTION
Here's my first PR. I didn't rebuild the dist files or anything like that yet -- I'm going to submit another patch or two and wanted this to merge cleanly. @duerig, let me know what you think.

My plan is to enable multipart uploads (and non-json POST
bodies) with needle. This should also support HTTP compression,
and fix the server-side API.
